### PR TITLE
Replaced deprecated itermitems() with items()

### DIFF
--- a/pyqb/__init__.py
+++ b/pyqb/__init__.py
@@ -176,7 +176,7 @@ class Client():
             database = self.database
 
         f = []
-        for k, v in fields.itermitems():
+        for k, v in fields.items():
             try:
                 int(k)
                 f.append((v, {"fid": k}))


### PR DESCRIPTION
This change was required for addrecord to work for me.

I'm using Python 2.7.10, but I understand that `iteritems()` was replaced with `items()` in Python 3