### PR TITLE
Use requests.Session(), cleanup a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,127 @@
-*.pyc
-/dist/
-/build/
-/*.egg-info
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# editors
+.vscode/

--- a/pyqb/__init__.py
+++ b/pyqb/__init__.py
@@ -64,12 +64,13 @@ class QBRequest():
 
 class Client():
     def __init__(self, url="http://www.quickbase.com", database=None,
-                 proxy=None, user_token=None):
+                 proxy=None, user_token=None, session=None):
         """Creates a client and authenticate to the URL/db"""
         self.user_token = user_token
         self.url = url
         self.database = database
         self.ticket = None
+        self.session = session or requests.Session()
         if proxy:
             self.proxy = {
                 'http': proxy,
@@ -112,7 +113,7 @@ class Client():
         return parsed
 
     def __make_req(self, url=None, headers=None, request=None):
-        res = requests.post(url, headers=headers, data=request.tostring(), proxies=self.proxy)
+        res = self.session.post(url, headers=headers, data=request.tostring(), proxies=self.proxy)
         return res
 
     def doquery(self, query=None, qid=None, qname=None, database=None,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pyqb',
-      version='0.2.2',
+      version='0.2.3',
       description='Quickbase API Python Wrapper',
       url='http://github.com/sjmh/pyqb',
       author='Steven Hajducko',
@@ -19,7 +19,7 @@ setup(name='pyqb',
                   'Programming Language :: Python :: 2.7',
                   'Programming Language :: Python :: 3'
       ],
-      keyworks=['quickbase'],
+      keywords=['quickbase'],
       packages=['pyqb'],
       install_requires=[
           'xmltodict',


### PR DESCRIPTION
To reduce overhead from multiple requests, start using the session functionality from requests.

Drop listed support for super-old versions of python which pyqb's dependencies don't even support.

Fixed typo for `keywords` in setup.py

Expanded gitignore to cover more possible junk.

Bumped the version in `setup.py` for pypi deployment.