### PR TITLE
Add useFids to doquery

### DIFF
--- a/pyqb/__init__.py
+++ b/pyqb/__init__.py
@@ -117,7 +117,7 @@ class Client():
         return res
 
     def doquery(self, query=None, qid=None, qname=None, database=None,
-                fields=None, fmt=False, rids=False, sort_fields=None, options=False):
+                fields=None, fmt=False, rids=False, sort_fields=None, options=False, fids=False):
         req = {}
         if query is not None:
             req["query"] = query
@@ -147,6 +147,10 @@ class Client():
 
         if options:
             req["options"] = options
+            
+        if fids:
+            req["useFids"] = 1
+            
         res = self.__request('DoQuery', database, req)
         return xmltodict.parse(et.tostring(res))['qdbapi']
 


### PR DESCRIPTION
From the documentation:
```
useFids
Set this parameter to 1 to specify that the field ids of each field should be used for the field tags in the record aggregate, instead of field names, when fmt is not specified for the request. The field tags will match those in the structured response.
```