### PR TITLE
Wrap query and records_csv fields with CDATA

### DIFF
--- a/pyqb/__init__.py
+++ b/pyqb/__init__.py
@@ -43,7 +43,10 @@ class QBRequest():
         # 'fieldname': 'value'
         if isinstance(v, six.string_types):
             e = et.SubElement(body, f)
-            e.text = v
+            if f in ['query', 'records_csv']:
+                e.append(et.Comment('--><![CDATA[' + v + ']]><!--'))
+            else:
+                e.text = v
 
         # Change ints to strings
         if isinstance(v, int):


### PR DESCRIPTION
We are having trouble with this API when making `doquery` and `importfromcsv` requests.

The problem occurs when either the `query` or `records_csv` fields contain special characters, such as `&`, `%` or `<`.

These are causing `XML` parsing issues. We have been trying to combat this by replacing such special characters with their encoded counterparts, but we are fighting a losing battle.

Luckily, it seems that there is a relatively simple solution to the problem. If you wrap the problem `XML` data fields with a `CDATA` tag, the problem goes away.

This is actually the recommended approach in the [documentation for **importfromcsv**](https://help.quickbase.com/api-guide/importfromcsv.html)

Unfortunately, `ElementTree` does not seem to support `CDATA`. There is another library, [lxml](https://lxml.de/) with a near-identical API to `xml.etree` that does support [CDATA](https://lxml.de/api.html#cdata). 

Instead of replacing the library, I had to resort to a somewhat hacky solution, but it seemed the least intrusive out of the available solutions I could find online and withing these [answers on StackOverflow](https://stackoverflow.com/questions/174890/how-to-output-cdata-using-elementtree).



